### PR TITLE
Transition action: Get token from keychain

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -2,6 +2,7 @@ const Jira = require('./jira');
 const sh = require('./alfred-exec');
 const config = require('./jira/config');
 const fs = require('fs');
+const keychain = require('./jira/keychain');
 const cfgFile = config.cfgPath + config.cfgFile;
 
 let args = process.argv.slice(2)[0].split(' ');
@@ -72,7 +73,8 @@ switch(query) {
       .catch(console.log);
   break;
   case 'transition':
-    let [ticketId, action, token] = args;
+    let [ticketId, action] = args;
+    token = keychain.find()
     Jira.transition(ticketId, action, token);
     Jira.clearCache(...bookmarks(), 'in-progress');
   break;


### PR DESCRIPTION
Transitioning a ticket via the workflow wasn't working for me - after choosing a new status type for a ticket, the workflow would fail silently.

In the debugger the issue manifested itself via this error message;
```
[ERROR: action.script] Must supply ticketId, action, and token
```

Debugging the issue revealed that the `token` variable (required by `Jira.transition()`) was `undefined`, because the `args` variable only contained the  values for `ticketId` and `action`.

In this PR I have changed the way the `token` variable is set prior to invoking `Jira.transition()` - it is now set by the result of `keychain.find()`.

With this change in place on my fork, I'm now able to alter the status of a ticket without an issue.
