### PR TITLE
Fix electron run parsing by removing warnings

### DIFF
--- a/lib/jira/auth.js
+++ b/lib/jira/auth.js
@@ -20,10 +20,16 @@ let Auth = {
 
       let token = keychain.find();
       let result = null;
+
       try {
         result = JSON.parse(stdout);
-      } catch(e) {
-        log('Unable to parse JSON response from stdout', e);
+      } catch (e) {
+        // Try stripping first line, might be electron run warning output
+        result = JSON.parse(stdout.replace(/^.*\n/, ""));
+
+        if (!result) {
+          log('Unable to parse JSON response from stdout', e);
+        }
       }
 
       if (result && token) {


### PR DESCRIPTION
electron run might print warnings to stdout on login,
complicating json parsing.