### PR TITLE
Support spaces in validateRepo() path

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -10,9 +10,9 @@ function validateRepo() {
   let gitDir = process.cwd() + '/.git',
       exists = fs.existsSync(gitDir);
   if (exists) {
-    let pushUrl = sh.execSync("grep -A1 '\"origin\"' " + gitDir 
-      + "/config | tail -n 1 | awk '{ print $3 }'").toString();
-    
+    let pushUrl = sh.execSync("grep -A1 '\"origin\"' \"" + gitDir
+      + "/config\" | tail -n 1 | awk '{ print $3 }'").toString();
+
     if (!/steyep/.test(pushUrl)) {
       sh.execSync("git remote set-url origin git@github.com:steyep/alfred-jira.git");
       sh.execSync("git remote set-url --push origin " + pushUrl);


### PR DESCRIPTION
If there's a space in your installation folder's path name, the workflow is unusable due to the grep command failing.