### PR TITLE
Only list projects that the user has permission to access

### DIFF
--- a/lib/jira/projects.js
+++ b/lib/jira/projects.js
@@ -20,12 +20,12 @@ module.exports = {
         })
         .catch(res => {
           let err = res.response;
-          if (!err) { 
-            reject('Unable to receive response from: ' + 
+          if (!err) {
+            reject('Unable to receive response from: ' +
               config.url + ' ' + '\n' + res)
           }
           if (err.status === 403) {
-            console.log('Too many failed login attempts: \n%s', 
+            console.log('Too many failed login attempts: \n%s',
               err.headers['x-authentication-denied-reason'])
           }
           reject(err.status + ': ' + err.statusText);
@@ -36,12 +36,12 @@ module.exports = {
   'getProjects': () => {
     return new Promise((resolve, reject) => {
       request
-        .get(config.url + 'rest/api/2/project', config.req)
+        .post(config.url + 'rest/api/2/permissions/project', {permissions: ["BROWSE_PROJECTS"]} , config.req)
         .then(res => {
           if (res.status !== 200) {
             reject(new Error(res.statusText));
           }
-          let projects = res.data.map( project => {
+          let projects = res.data.projects.map( project => {
             return {
               name: project.key,
               enabled: true
@@ -51,12 +51,12 @@ module.exports = {
         })
         .catch(res => {
             let err = res.response;
-            if (!err) { 
-              reject('Unable to receive response from: ' + 
+            if (!err) {
+              reject('Unable to receive response from: ' +
                 config.url + ' ' + '\n' + res)
             }
             if (err.status === 403) {
-              console.log('Too many failed login attempts: \n%s', 
+              console.log('Too many failed login attempts: \n%s',
                 err.headers['x-authentication-denied-reason'])
             }
             reject(err.status + ': ' + err.statusText);


### PR DESCRIPTION
Currently the getProjects() function fetches the list of all available projects in JIRA, but does no error checking to see if the user has permission to view the issues in all the projects.

In the current version of alfred-jira, I have to manually choose which projects to use in bookmark queries, otherwise I get a "400 Bad Request" until I disable the project that is causing the issue (this is identifiable via the debugger).

This PR changes the REST method that alfred-jira uses to fetch project names - it now uses the ["Get Permitted Projects" API](https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-permissions-project-post), which returns a list of project names, filtering out any projects to which the user does not have read access.

I'm aware that it's an experimental API, so you may still want to keep the old behaviour for backwards compatibility - perhaps have a fallback to the old function, or give the user the ability to choose the behaviour via the GUI.