### PR TITLE
Electron warning messages are preventing user login

### DIFF
--- a/lib/jira/auth.js
+++ b/lib/jira/auth.js
@@ -25,6 +25,9 @@ let Auth = {
         result = JSON.parse(stdout);
       } catch (e) {
         // Try stripping first line, might be electron run warning output
+
+        stdout = stdout.split("\n").pop()
+
         result = JSON.parse(stdout.replace(/^.*\n/, ""));
 
         if (!result) {


### PR DESCRIPTION
MacOS version: 10.14.4 (18E226)
Node version: v11.12.0
Workflow version: v1.0.8

I was having issues setting up alfred-jira on a fresh install of MacOS - I was trying to log in, but the process was failing (no configuration files created, and I was re-prompted for login details next time I invoked the workflow).

I ran the Alfred debugger and got this when I clicked the "Login" button after entering my details;

```
SyntaxError: Unexpected token e in JSON at position 0
    at JSON.parse (<anonymous>)
    at /Users/edmundd/Development/alfred-jira/lib/jira/auth.js:35:23
    at ChildProcess.exithandler (child_process.js:288:7)
    at ChildProcess.emit (events.js:197:13)
    at maybeClose (internal/child_process.js:988:16)
    at Socket.stream.socket.on (internal/child_process.js:404:11)
    at Socket.emit (events.js:197:13)
    at Pipe._handle.close (net.js:611:12)
```

Adding some extra debugging uncovered the cause of the issue: Electron is logging warning messages to stdout, which the JSON.parse() function doesn't expect.

```
2019-03-27 11:11:15.384 Electron[7759:160820] isPrefsCreateCacheFromEnabledAndDefaultInputSources - can't find anything from GetInputSourceEnabledPrefs, use defaultASCIIKeyLayoutDict = <CFBasicHash 0x7f9d5ce3b640 [0x7fffa340b8f0]>{type = mutable dict, count = 3,
entries =>
	0 : <CFString 0x7fffa34767f8 [0x7fffa340b8f0]>{contents = "InputSourceKind"} = <CFString 0x7fffa34bbd38 [0x7fffa340b8f0]>{contents = "Keyboard Layout"}
	1 : <CFString 0x7fffa34a7e78 [0x7fffa340b8f0]>{contents = "KeyboardLayout ID"} = <CFNumber 0x237 [0x7fffa340b8f0]>{value = +2, type = kCFNumberSInt64Type}
	9 : <CFString 0x7fffa34714f8 [0x7fffa340b8f0]>{contents = "KeyboardLayout Name"} = British
}
2019-03-27 11:11:15.426 Electron[7759:160820] *** WARNING: Textured window <AtomNSWindow: 0x7f9d5cc6e840> is getting an implicitly transparent titlebar. This will break when linking against newer SDKs. Use NSWindow's -titlebarAppearsTransparent=YES instead.
{"url":"https://myjiraurl/","user":",myjirauser"}
```

The commit in my PR is what I used to get around the issue, it just filters the stdout variable to only read the last line (which contains the JSON). Admittedly this is a bit of a hack, as it doesn't solve the actual problem, the cause of the Electron warnings.